### PR TITLE
The drawer's state is not retained properly when orientation changed repeatedly.

### DIFF
--- a/library/src/net/simonvt/widget/MenuDrawer.java
+++ b/library/src/net/simonvt/widget/MenuDrawer.java
@@ -916,5 +916,6 @@ public class MenuDrawer extends ViewGroup {
         Bundle state = (Bundle) in;
         final boolean menuOpen = state.getBoolean(STATE_MENU_VISIBLE);
         setContentLeft(menuOpen ? mMenuWidth : 0);
+        mDrawerState = menuOpen ? STATE_OPEN : STATE_CLOSED;
     }
 }


### PR DESCRIPTION
If the screen orientation changes twice while the menu is open, it becomes closed state.

The menu drawer should save the state to this issue. 
