### PR TITLE
Add support for setting menu width

### DIFF
--- a/library/src/net/simonvt/widget/MenuDrawer.java
+++ b/library/src/net/simonvt/widget/MenuDrawer.java
@@ -214,9 +214,10 @@ public abstract class MenuDrawer extends ViewGroup {
     protected int mMenuWidth;
 
     /**
-     * Indicates whether the menu width has been set in the theme.
+     * Indicates whether the menu width has been set explicity either via the
+     * theme or by calling {@link #setWidth(int)}
      */
-    private boolean mMenuWidthFromTheme;
+    private boolean mMenuWidthSet;
 
     /**
      * Current left position of the content.
@@ -374,7 +375,7 @@ public abstract class MenuDrawer extends ViewGroup {
         final Drawable menuBackground = a.getDrawable(R.styleable.MenuDrawer_mdMenuBackground);
 
         mMenuWidth = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdMenuWidth, -1);
-        mMenuWidthFromTheme = mMenuWidth != -1;
+        mMenuWidthSet = mMenuWidth != -1;
 
         final int arrowResId = a.getResourceId(R.styleable.MenuDrawer_mdArrowDrawable, 0);
         if (arrowResId != 0) {
@@ -475,6 +476,21 @@ public abstract class MenuDrawer extends ViewGroup {
      */
     public boolean isMenuVisible() {
         return mMenuVisible;
+    }
+
+    /**
+     * Set the width of the menu drawer when open.
+     *
+     * @param width
+     */
+    public void setMenuWidth(final int width) {
+        mMenuWidth = width;
+        mMenuWidthSet = true;
+        if (mDrawerState == STATE_OPEN || mDrawerState == STATE_OPENING) {
+            setOffsetPixels(mMenuWidth);
+        }
+        requestLayout();
+        invalidate();
     }
 
     /**
@@ -757,7 +773,7 @@ public abstract class MenuDrawer extends ViewGroup {
         final int width = MeasureSpec.getSize(widthMeasureSpec);
         final int height = MeasureSpec.getSize(heightMeasureSpec);
 
-        if (!mMenuWidthFromTheme) mMenuWidth = (int) (width * 0.8f);
+        if (!mMenuWidthSet) mMenuWidth = (int) (width * 0.8f);
         if (mOffsetPixels == -1) setOffsetPixels(mMenuWidth);
 
         final int menuWidthMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, mMenuWidth);


### PR DESCRIPTION
This adds a `setWidth` method to `MenuDrawer` allowing the width of the drawer when open to be set explicitly instead of via the theme.

Having dynamic menu items in the drawer can require doing some measurements before knowing how big the drawer should be.

If there is already a way to do this please let me know and I will close this request.
