### PR TITLE
Support for placing the drawer above the content.

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -12,7 +12,10 @@
         <!-- Drawable to use for the background of the menu. -->
         <attr name="mdMenuBackground" format="reference" />
 
-        <!-- The width of the menu. -->
+        <!-- The size of the menu. -->
+        <attr name="mdMenuSize" format="dimension" />
+
+        <!-- This attribute is deprecated. Please use mdMenuSize instead. -->
         <attr name="mdMenuWidth" format="dimension" />
 
         <!-- Drawable to use for the arrow indicator. -->
@@ -21,8 +24,11 @@
         <!-- Defines whether the content will have a dropshadow onto the menu. Default is true. -->
         <attr name="mdDropShadowEnabled" format="boolean" />
 
-        <!-- The width of the drop shadow. Default is 6dp. -->
+        <!-- This attribute is deprecated. Please use mdDropShadowSize instead. -->
         <attr name="mdDropShadowWidth" format="dimension" />
+
+        <!-- The size of the drop shadow. Default is 6dp -->
+        <attr name="mdDropShadowSize" format="dimension" />
 
         <!-- The color of the drop shadow. Default is #FF000000. -->
         <attr name="mdDropShadowColor" format="color" />
@@ -30,6 +36,6 @@
         <!-- Drawable used for the drop shadow. -->
         <attr name="mdDropShadow" format="reference" />
 
-    </declare-styleable>
+        </declare-styleable>
 
 </resources>

--- a/library/src/net/simonvt/widget/HorizontalMenuDrawer.java
+++ b/library/src/net/simonvt/widget/HorizontalMenuDrawer.java
@@ -1,0 +1,191 @@
+package net.simonvt.widget;
+
+import android.app.Activity;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+
+public abstract class HorizontalMenuDrawer extends MenuDrawer {
+
+    HorizontalMenuDrawer(Activity activity, int dragMode) {
+        super(activity, dragMode);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
+        final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+
+        if (widthMode != MeasureSpec.EXACTLY || heightMode != MeasureSpec.EXACTLY) {
+            throw new IllegalStateException("Must measure with an exact size");
+        }
+
+        final int width = MeasureSpec.getSize(widthMeasureSpec);
+        final int height = MeasureSpec.getSize(heightMeasureSpec);
+
+        if (!mMenuSizeSet)
+            mMenuSize = (int) (height * 0.25f);
+        if (mOffsetPixels == -1)
+            setOffsetPixels(mMenuSize);
+
+        final int menuWidthMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, width);
+        final int menuHeightMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, mMenuSize);
+        mMenuContainer.measure(menuWidthMeasureSpec, menuHeightMeasureSpec);
+
+        final int contentWidthMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, width);
+        final int contentHeightMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, height);
+        mContentContainer.measure(contentWidthMeasureSpec, contentHeightMeasureSpec);
+
+        setMeasuredDimension(width, height);
+
+        updateTouchAreaSize();
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        final int action = ev.getAction() & MotionEvent.ACTION_MASK;
+
+        if (action == MotionEvent.ACTION_DOWN && mMenuVisible && isCloseEnough()) {
+            setOffsetPixels(0);
+            stopAnimation();
+            endPeek();
+            setDrawerState(STATE_CLOSED);
+        }
+
+        // Always intercept events over the content while menu is visible.
+        if (mMenuVisible && isContentTouch(ev))
+            return true;
+
+        if (mTouchMode == TOUCH_MODE_NONE) {
+            return false;
+        }
+
+        if (action != MotionEvent.ACTION_DOWN) {
+            if (mIsDragging)
+                return true;
+        }
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN: {
+                mLastMotionX = mInitialMotionX = ev.getX();
+                mLastMotionY = mInitialMotionY = ev.getY();
+                final boolean allowDrag = onDownAllowDrag(ev);
+
+                if (allowDrag) {
+                    setDrawerState(mMenuVisible ? STATE_OPEN : STATE_CLOSED);
+                    stopAnimation();
+                    endPeek();
+                    mIsDragging = false;
+                }
+                break;
+            }
+
+            case MotionEvent.ACTION_MOVE: {
+                final float x = ev.getX();
+                final float dx = x - mLastMotionX;
+                final float xDiff = Math.abs(dx);
+                final float y = ev.getY();
+                final float dy = y - mLastMotionY;
+                final float yDiff = Math.abs(dy);
+
+                if (yDiff > mTouchSlop && yDiff > xDiff) {
+                    final boolean allowDrag = onMoveAllowDrag(ev, dy);
+
+                    if (allowDrag) {
+                        setDrawerState(STATE_DRAGGING);
+                        mIsDragging = true;
+                        mLastMotionX = x;
+                        mLastMotionY = y;
+                    }
+                }
+                break;
+            }
+
+            /**
+             * If you click really fast, an up or cancel event is delivered here. Just snap content to
+             * whatever is closest.
+             */
+            case MotionEvent.ACTION_CANCEL:
+            case MotionEvent.ACTION_UP: {
+                final int offsetPixels = mOffsetPixels;
+                animateOffsetTo(offsetPixels > mMenuSize / 2 ? mMenuSize : 0, 0, true);
+                break;
+            }
+        }
+
+        if (mVelocityTracker == null)
+            mVelocityTracker = VelocityTracker.obtain();
+        mVelocityTracker.addMovement(ev);
+
+        return mIsDragging;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        if (!mMenuVisible && (mTouchMode == TOUCH_MODE_NONE)) {
+            return false;
+        }
+        final int action = ev.getAction() & MotionEvent.ACTION_MASK;
+
+        if (mVelocityTracker == null)
+            mVelocityTracker = VelocityTracker.obtain();
+        mVelocityTracker.addMovement(ev);
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN: {
+                mLastMotionX = mInitialMotionX = ev.getX();
+                mLastMotionY = mInitialMotionY = ev.getY();
+                final boolean allowDrag = onDownAllowDrag(ev);
+
+                if (allowDrag) {
+                    stopAnimation();
+                    endPeek();
+                    startLayerTranslation();
+                }
+                break;
+            }
+
+            case MotionEvent.ACTION_MOVE: {
+                if (!mIsDragging) {
+                    final float x = ev.getX();
+                    final float dx = x - mLastMotionX;
+                    final float xDiff = Math.abs(dx);
+                    final float y = ev.getY();
+                    final float dy = y - mLastMotionY;
+                    final float yDiff = Math.abs(dy);
+
+                    if (yDiff > mTouchSlop && yDiff > xDiff) {
+                        final boolean allowDrag = onMoveAllowDrag(ev, dy);
+
+                        if (allowDrag) {
+                            setDrawerState(STATE_DRAGGING);
+                            mIsDragging = true;
+                            mLastMotionY = y - mInitialMotionY > 0
+                                    ? mInitialMotionY + mTouchSlop
+                                    : mInitialMotionY - mTouchSlop;
+                        }
+                    }
+                }
+
+                if (mIsDragging) {
+                    startLayerTranslation();
+
+                    final float y = ev.getY();
+                    final float dy = y - mLastMotionY;
+
+                    mLastMotionY = y;
+                    onMoveEvent(dy);
+                }
+                break;
+            }
+
+            case MotionEvent.ACTION_CANCEL:
+            case MotionEvent.ACTION_UP: {
+                onUpEvent(ev);
+                break;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/library/src/net/simonvt/widget/LeftDrawer.java
+++ b/library/src/net/simonvt/widget/LeftDrawer.java
@@ -29,7 +29,7 @@ public class LeftDrawer extends MenuDrawer {
         final int height = b - t;
         final int offsetPixels = mOffsetPixels;
 
-        mMenuContainer.layout(0, 0, mMenuWidth, height);
+        mMenuContainer.layout(0, 0, mMenuSize, height);
         offsetMenu(offsetPixels);
 
         if (USE_TRANSLATIONS) {
@@ -45,8 +45,8 @@ public class LeftDrawer extends MenuDrawer {
      * @param offsetPixels The number of pixels the content if offset.
      */
     private void offsetMenu(int offsetPixels) {
-        if (mOffsetMenu && mMenuWidth != 0) {
-            final int menuWidth = mMenuWidth;
+        if (mOffsetMenu && mMenuSize != 0) {
+            final int menuWidth = mMenuSize;
             final float openRatio = (menuWidth - (float) offsetPixels) / menuWidth;
 
             if (USE_TRANSLATIONS) {
@@ -65,14 +65,14 @@ public class LeftDrawer extends MenuDrawer {
     protected void drawDropShadow(Canvas canvas, int offsetPixels) {
         final int height = getHeight();
 
-        mDropShadowDrawable.setBounds(offsetPixels - mDropShadowWidth, 0, offsetPixels, height);
+        mDropShadowDrawable.setBounds(offsetPixels - mDropShadowSize, 0, offsetPixels, height);
         mDropShadowDrawable.draw(canvas);
     }
 
     @Override
     protected void drawMenuOverlay(Canvas canvas, int offsetPixels) {
         final int height = getHeight();
-        final float openRatio = ((float) offsetPixels) / mMenuWidth;
+        final float openRatio = ((float) offsetPixels) / mMenuSize;
 
         mMenuOverlay.setBounds(0, 0, offsetPixels, height);
         mMenuOverlay.setAlpha((int) (MAX_MENU_OVERLAY_ALPHA * (1.f - openRatio)));
@@ -86,7 +86,7 @@ public class LeftDrawer extends MenuDrawer {
             final int pos = position == null ? 0 : position;
 
             if (pos == mActivePosition) {
-                final float openRatio = ((float) offsetPixels) / mMenuWidth;
+                final float openRatio = ((float) offsetPixels) / mMenuSize;
 
                 mActiveView.getDrawingRect(mActiveRect);
                 offsetDescendantRectToMyCoords(mActiveView, mActiveRect);
@@ -126,19 +126,19 @@ public class LeftDrawer extends MenuDrawer {
 
     @Override
     protected boolean onDownAllowDrag(MotionEvent ev) {
-        return (!mMenuVisible && mInitialMotionX <= mTouchWidth)
+        return (!mMenuVisible && mInitialMotionX <= mTouchSize)
                 || (mMenuVisible && mInitialMotionX >= mOffsetPixels);
     }
 
     @Override
     protected boolean onMoveAllowDrag(MotionEvent ev, float diff) {
-        return (!mMenuVisible && mInitialMotionX <= mTouchWidth && (diff > 0))
+        return (!mMenuVisible && mInitialMotionX <= mTouchSize && (diff > 0))
                 || (mMenuVisible && mInitialMotionX >= mOffsetPixels);
     }
 
     @Override
     protected void onMoveEvent(float dx) {
-        setOffsetPixels(Math.min(Math.max(mOffsetPixels + (int) dx, 0), mMenuWidth));
+        setOffsetPixels(Math.min(Math.max(mOffsetPixels + (int) dx, 0), mMenuSize));
     }
 
     @Override
@@ -149,7 +149,7 @@ public class LeftDrawer extends MenuDrawer {
             mVelocityTracker.computeCurrentVelocity(1000, mMaxVelocity);
             final int initialVelocity = (int) mVelocityTracker.getXVelocity();
             mLastMotionX = ev.getX();
-            animateOffsetTo(mVelocityTracker.getXVelocity() > 0 ? mMenuWidth : 0, initialVelocity, true);
+            animateOffsetTo(mVelocityTracker.getXVelocity() > 0 ? mMenuSize : 0, initialVelocity, true);
 
             // Close the menu when content is clicked while the menu is visible.
         } else if (mMenuVisible && ev.getX() > offsetPixels) {

--- a/library/src/net/simonvt/widget/MenuDrawer.java
+++ b/library/src/net/simonvt/widget/MenuDrawer.java
@@ -190,9 +190,9 @@ public abstract class MenuDrawer extends ViewGroup {
     protected Drawable mDropShadowDrawable;
 
     /**
-     * The width of the content drop shadow.
+     * The size of the content drop shadow.
      */
-    protected int mDropShadowWidth;
+    protected int mDropShadowSize;
 
     /**
      * Arrow bitmap used to indicate the active view.
@@ -230,15 +230,15 @@ public abstract class MenuDrawer extends ViewGroup {
     protected BuildLayerFrameLayout mContentContainer;
 
     /**
-     * The width of the menu.
+     * The size of the menu (width or height depending on the gravity).
      */
-    protected int mMenuWidth;
+    protected int mMenuSize;
 
     /**
-     * Indicates whether the menu width has been set explicity either via the theme or by calling
-     * {@link #setMenuWidth(int)}.
+     * Indicates whether the menu size has been set explicity either via the theme or by calling
+     * {@link #setMenuSize(int)}.
      */
-    private boolean mMenuWidthSet;
+    protected boolean mMenuSizeSet;
 
     /**
      * Current left position of the content.
@@ -267,14 +267,14 @@ public abstract class MenuDrawer extends ViewGroup {
     private int mDrawerState = STATE_CLOSED;
 
     /**
-     * The maximum touch area width of the drawer in px.
+     * The maximum touch area size of the drawer in px.
      */
-    protected int mMaxTouchBezelWidth;
+    protected int mMaxTouchBezelSize;
 
     /**
-     * The touch area width of the drawer in px.
+     * The touch area size of the drawer in px.
      */
-    protected int mTouchWidth;
+    protected int mTouchSize;
 
     /**
      * Indicates whether the drawer is currently being dragged.
@@ -305,6 +305,7 @@ public abstract class MenuDrawer extends ViewGroup {
      * Runnable used when animating the drawer open/closed.
      */
     private final Runnable mDragRunnable = new Runnable() {
+        @Override
         public void run() {
             postAnimationInvalidate();
         }
@@ -482,8 +483,12 @@ public abstract class MenuDrawer extends ViewGroup {
         final Drawable contentBackground = a.getDrawable(R.styleable.MenuDrawer_mdContentBackground);
         final Drawable menuBackground = a.getDrawable(R.styleable.MenuDrawer_mdMenuBackground);
 
-        mMenuWidth = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdMenuWidth, -1);
-        mMenuWidthSet = mMenuWidth != -1;
+        mMenuSize = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdMenuSize, -1);
+        if (mMenuSize == -1) {
+            // 'mdMenuSize' not set. Try deprecated 'mdMenuWidth' instead.
+            mMenuSize = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdMenuWidth, -1);
+        }
+        mMenuSizeSet = mMenuSize != -1;
 
         final int arrowResId = a.getResourceId(R.styleable.MenuDrawer_mdArrowDrawable, 0);
         if (arrowResId != 0) {
@@ -499,7 +504,11 @@ public abstract class MenuDrawer extends ViewGroup {
             setDropShadowColor(dropShadowColor);
         }
 
-        mDropShadowWidth = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdDropShadowWidth, dpToPx(6));
+        mDropShadowSize = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdDropShadowSize, -1);
+        if (mDropShadowSize == -1) {
+            // 'mdDropShadowSize' not set. Try deprecated 'mdDropShadowWidth' instead.
+            mDropShadowSize = a.getDimensionPixelSize(R.styleable.MenuDrawer_mdDropShadowWidth, dpToPx(6));
+        }
 
         a.recycle();
 
@@ -522,7 +531,7 @@ public abstract class MenuDrawer extends ViewGroup {
         mScroller = new Scroller(activity, SMOOTH_INTERPOLATOR);
         mPeekScroller = new Scroller(activity, PEEK_INTERPOLATOR);
 
-        mMaxTouchBezelWidth = dpToPx(MAX_DRAG_BEZEL_DP);
+        mMaxTouchBezelSize = dpToPx(MAX_DRAG_BEZEL_DP);
         mCloseEnough = dpToPx(CLOSE_ENOUGH);
     }
 
@@ -563,7 +572,7 @@ public abstract class MenuDrawer extends ViewGroup {
      * @param animate Whether open/close should be animated.
      */
     public void openMenu(boolean animate) {
-        animateOffsetTo(mMenuWidth, 0, animate);
+        animateOffsetTo(mMenuSize, 0, animate);
     }
 
     /**
@@ -592,18 +601,30 @@ public abstract class MenuDrawer extends ViewGroup {
     }
 
     /**
+     * Set the size of the menu drawer when open.
+     *
+     * @param size
+     */
+    public void setMenuSize(final int size) {
+        mMenuSize = size;
+        mMenuSizeSet = true;
+        if (mDrawerState == STATE_OPEN || mDrawerState == STATE_OPENING) {
+            setOffsetPixels(mMenuSize);
+        }
+        requestLayout();
+        invalidate();
+    }
+
+    /**
+     * @deprecated Please use {@link #setMenuSize} instead.
+     *
      * Set the width of the menu drawer when open.
      *
      * @param width
      */
+    @Deprecated
     public void setMenuWidth(final int width) {
-        mMenuWidth = width;
-        mMenuWidthSet = true;
-        if (mDrawerState == STATE_OPEN || mDrawerState == STATE_OPENING) {
-            setOffsetPixels(mMenuWidth);
-        }
-        requestLayout();
-        invalidate();
+        setMenuSize(width);
     }
 
     /**
@@ -713,13 +734,25 @@ public abstract class MenuDrawer extends ViewGroup {
     }
 
     /**
+     * Sets the size of the drop shadow.
+     *
+     * @param size The size of the drop shadow in px.
+     */
+    public void setDropShadowSize(int size) {
+        mDropShadowSize = size;
+        invalidate();
+    }
+
+    /**
+     * @deprecated Please use setDropShadowSize instead.
+     *
      * Sets the width of the drop shadow.
      *
      * @param width The width of the drop shadow in px.
      */
+    @Deprecated
     public void setDropShadowWidth(int width) {
-        mDropShadowWidth = width;
-        invalidate();
+        setDropShadowSize(width);
     }
 
     /**
@@ -949,7 +982,7 @@ public abstract class MenuDrawer extends ViewGroup {
     public void setTouchMode(int mode) {
         if (mTouchMode != mode) {
             mTouchMode = mode;
-            updateTouchAreaWidth();
+            updateTouchAreaSize();
         }
     }
 
@@ -1042,10 +1075,10 @@ public abstract class MenuDrawer extends ViewGroup {
         final int width = MeasureSpec.getSize(widthMeasureSpec);
         final int height = MeasureSpec.getSize(heightMeasureSpec);
 
-        if (!mMenuWidthSet) mMenuWidth = (int) (width * 0.8f);
-        if (mOffsetPixels == -1) setOffsetPixels(mMenuWidth);
+        if (!mMenuSizeSet) mMenuSize = (int) (width * 0.8f);
+        if (mOffsetPixels == -1) setOffsetPixels(mMenuSize);
 
-        final int menuWidthMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, mMenuWidth);
+        final int menuWidthMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, mMenuSize);
         final int menuHeightMeasureSpec = getChildMeasureSpec(widthMeasureSpec, 0, height);
         mMenuContainer.measure(menuWidthMeasureSpec, menuHeightMeasureSpec);
 
@@ -1055,7 +1088,7 @@ public abstract class MenuDrawer extends ViewGroup {
 
         setMeasuredDimension(width, height);
 
-        updateTouchAreaWidth();
+        updateTouchAreaSize();
     }
 
     @Override
@@ -1069,13 +1102,13 @@ public abstract class MenuDrawer extends ViewGroup {
     /**
      * Compute the touch area based on the touch mode.
      */
-    private void updateTouchAreaWidth() {
+    protected void updateTouchAreaSize() {
         if (mTouchMode == TOUCH_MODE_BEZEL) {
-            mTouchWidth = Math.min(getMeasuredWidth() / 10, mMaxTouchBezelWidth);
+            mTouchSize = Math.min(getMeasuredWidth() / 10, mMaxTouchBezelSize);
         } else if (mTouchMode == TOUCH_MODE_FULLSCREEN) {
-            mTouchWidth = getMeasuredWidth();
+            mTouchSize = getMeasuredWidth();
         } else {
-            mTouchWidth = 0;
+            mTouchSize = 0;
         }
     }
 
@@ -1137,7 +1170,7 @@ public abstract class MenuDrawer extends ViewGroup {
         if (velocity > 0) {
             duration = 4 * Math.round(1000.f * Math.abs((float) dx / velocity));
         } else {
-            duration = (int) (600.f * Math.abs((float) dx / mMenuWidth));
+            duration = (int) (600.f * Math.abs((float) dx / mMenuSize));
         }
 
         duration = Math.min(duration, DURATION_MAX);
@@ -1177,7 +1210,7 @@ public abstract class MenuDrawer extends ViewGroup {
      * Starts peek drawer animation.
      */
     protected void startPeek() {
-        final int menuWidth = mMenuWidth;
+        final int menuWidth = mMenuSize;
         final int dx = menuWidth / 3;
         mPeekScroller.startScroll(0, 0, dx, 0, PEEK_DURATION);
 
@@ -1349,7 +1382,7 @@ public abstract class MenuDrawer extends ViewGroup {
             case MotionEvent.ACTION_CANCEL:
             case MotionEvent.ACTION_UP: {
                 final int offsetPixels = mOffsetPixels;
-                animateOffsetTo(offsetPixels > mMenuWidth / 2 ? mMenuWidth : 0, 0, true);
+                animateOffsetTo(offsetPixels > mMenuSize / 2 ? mMenuSize : 0, 0, true);
                 break;
             }
         }
@@ -1447,7 +1480,7 @@ public abstract class MenuDrawer extends ViewGroup {
     public void restoreState(Parcelable in) {
         Bundle state = (Bundle) in;
         final boolean menuOpen = state.getBoolean(STATE_MENU_VISIBLE);
-        setOffsetPixels(menuOpen ? mMenuWidth : 0);
+        setOffsetPixels(menuOpen ? mMenuSize : 0);
         mDrawerState = menuOpen ? STATE_OPEN : STATE_CLOSED;
     }
 }

--- a/library/src/net/simonvt/widget/MenuDrawer.java
+++ b/library/src/net/simonvt/widget/MenuDrawer.java
@@ -125,6 +125,11 @@ public abstract class MenuDrawer extends ViewGroup {
     public static final int MENU_POSITION_RIGHT = 1;
 
     /**
+     * Position the menu above the content.
+     */
+    public static final int MENU_POSITION_TOP = 2;
+
+    /**
      * Disallow opening the drawer by dragging the screen.
      */
     public static final int TOUCH_MODE_NONE = 0;
@@ -292,6 +297,11 @@ public abstract class MenuDrawer extends ViewGroup {
     protected float mInitialMotionX;
 
     /**
+     * The initial Y position of a drag.
+     */
+    protected float mInitialMotionY;
+
+    /**
      * The last X position of a drag.
      */
     protected float mLastMotionX = -1;
@@ -421,9 +431,7 @@ public abstract class MenuDrawer extends ViewGroup {
      * @return The created MenuDrawer instance.
      */
     public static MenuDrawer attach(Activity activity, int dragMode, int gravity) {
-        MenuDrawer menuDrawer = gravity == MenuDrawer.MENU_POSITION_RIGHT
-                ? new RightDrawer(activity, dragMode)
-                : new LeftDrawer(activity, dragMode);
+        MenuDrawer menuDrawer = createMenuDrawer(activity, dragMode, gravity);
         menuDrawer.setId(R.id.md__layout);
 
         switch (dragMode) {
@@ -440,6 +448,23 @@ public abstract class MenuDrawer extends ViewGroup {
         }
 
         return menuDrawer;
+    }
+
+    /**
+     * Constructs the appropriate MenuDrawer based on the gravity.
+     */
+    private static MenuDrawer createMenuDrawer(Activity activity, int dragMode, int gravity) {
+        switch (gravity) {
+            case MenuDrawer.MENU_POSITION_LEFT:
+                return new LeftDrawer(activity, dragMode);
+            case MenuDrawer.MENU_POSITION_RIGHT:
+                return new RightDrawer(activity, dragMode);
+            case MenuDrawer.MENU_POSITION_TOP:
+                return new TopDrawer(activity, dragMode);
+            default:
+                throw new IllegalArgumentException(
+                        "gravity must be one of MENU_POSITION_LEFT, MENU_POSITION_TOP or MENU_POSITION_RIGHT");
+        }
     }
 
     /**
@@ -1343,7 +1368,7 @@ public abstract class MenuDrawer extends ViewGroup {
         switch (action) {
             case MotionEvent.ACTION_DOWN: {
                 mLastMotionX = mInitialMotionX = ev.getX();
-                mLastMotionY = ev.getY();
+                mLastMotionY = mInitialMotionY = ev.getY();
                 final boolean allowDrag = onDownAllowDrag(ev);
 
                 if (allowDrag) {
@@ -1406,7 +1431,7 @@ public abstract class MenuDrawer extends ViewGroup {
         switch (action) {
             case MotionEvent.ACTION_DOWN: {
                 mLastMotionX = mInitialMotionX = ev.getX();
-                mLastMotionY = ev.getY();
+                mLastMotionY = mInitialMotionY = ev.getY();
                 final boolean allowDrag = onDownAllowDrag(ev);
 
                 if (allowDrag) {

--- a/library/src/net/simonvt/widget/RightDrawer.java
+++ b/library/src/net/simonvt/widget/RightDrawer.java
@@ -29,7 +29,7 @@ public class RightDrawer extends MenuDrawer {
         final int height = b - t;
         final int offsetPixels = mOffsetPixels;
 
-        mMenuContainer.layout(width - mMenuWidth, 0, width, height);
+        mMenuContainer.layout(width - mMenuSize, 0, width, height);
         offsetMenu(offsetPixels);
 
         if (USE_TRANSLATIONS) {
@@ -45,8 +45,8 @@ public class RightDrawer extends MenuDrawer {
      * @param offsetPixels The number of pixels the content if offset.
      */
     private void offsetMenu(int offsetPixels) {
-        if (mOffsetMenu && mMenuWidth != 0) {
-            final int menuWidth = mMenuWidth;
+        if (mOffsetMenu && mMenuSize != 0) {
+            final int menuWidth = mMenuSize;
             final float openRatio = (menuWidth - (float) offsetPixels) / menuWidth;
 
             if (USE_TRANSLATIONS) {
@@ -68,7 +68,7 @@ public class RightDrawer extends MenuDrawer {
         final int height = getHeight();
         final int width = getWidth();
         final int left = width - offsetPixels;
-        final int right = left + mDropShadowWidth;
+        final int right = left + mDropShadowSize;
 
         mDropShadowDrawable.setBounds(left, 0, right, height);
         mDropShadowDrawable.draw(canvas);
@@ -80,7 +80,7 @@ public class RightDrawer extends MenuDrawer {
         final int width = getWidth();
         final int left = width - offsetPixels;
         final int right = width;
-        final float openRatio = ((float) offsetPixels) / mMenuWidth;
+        final float openRatio = ((float) offsetPixels) / mMenuSize;
 
         mMenuOverlay.setBounds(left, 0, right, height);
         mMenuOverlay.setAlpha((int) (MAX_MENU_OVERLAY_ALPHA * (1.f - openRatio)));
@@ -95,7 +95,7 @@ public class RightDrawer extends MenuDrawer {
 
             if (pos == mActivePosition) {
                 final int width = getWidth();
-                final int menuWidth = mMenuWidth;
+                final int menuWidth = mMenuSize;
                 final int arrowWidth = mArrowBitmap.getWidth();
 
                 final int contentRight = width - offsetPixels;
@@ -143,7 +143,7 @@ public class RightDrawer extends MenuDrawer {
         final int width = getWidth();
         final int initialMotionX = (int) mInitialMotionX;
 
-        return (!mMenuVisible && initialMotionX >= width - mTouchWidth)
+        return (!mMenuVisible && initialMotionX >= width - mTouchSize)
                 || (mMenuVisible && initialMotionX <= width - mOffsetPixels);
     }
 
@@ -152,13 +152,13 @@ public class RightDrawer extends MenuDrawer {
         final int width = getWidth();
         final int initialMotionX = (int) mInitialMotionX;
 
-        return (!mMenuVisible && initialMotionX >= width - mTouchWidth && (diff < 0))
+        return (!mMenuVisible && initialMotionX >= width - mTouchSize && (diff < 0))
                 || (mMenuVisible && initialMotionX <= width - mOffsetPixels);
     }
 
     @Override
     protected void onMoveEvent(float dx) {
-        setOffsetPixels(Math.min(Math.max(mOffsetPixels - (int) dx, 0), mMenuWidth));
+        setOffsetPixels(Math.min(Math.max(mOffsetPixels - (int) dx, 0), mMenuSize));
     }
 
     @Override
@@ -170,7 +170,7 @@ public class RightDrawer extends MenuDrawer {
             mVelocityTracker.computeCurrentVelocity(1000, mMaxVelocity);
             final int initialVelocity = (int) mVelocityTracker.getXVelocity();
             mLastMotionX = ev.getX();
-            animateOffsetTo(mVelocityTracker.getXVelocity() > 0 ? 0 : mMenuWidth, initialVelocity, true);
+            animateOffsetTo(mVelocityTracker.getXVelocity() > 0 ? 0 : mMenuSize, initialVelocity, true);
 
             // Close the menu when content is clicked while the menu is visible.
         } else if (mMenuVisible && ev.getX() < width - offsetPixels) {

--- a/library/src/net/simonvt/widget/TopDrawer.java
+++ b/library/src/net/simonvt/widget/TopDrawer.java
@@ -1,0 +1,137 @@
+package net.simonvt.widget;
+
+import android.app.Activity;
+import android.graphics.Canvas;
+import android.graphics.drawable.GradientDrawable;
+import android.view.MotionEvent;
+
+public class TopDrawer extends HorizontalMenuDrawer {
+
+    TopDrawer(Activity activity, int dragMode) {
+        super(activity, dragMode);
+    }
+
+    @Override
+    public void setDropShadowColor(int color) {
+        final int endColor = color & 0x00FFFFFF;
+        mDropShadowDrawable = new GradientDrawable(GradientDrawable.Orientation.BOTTOM_TOP,
+                new int[] {
+                        color,
+                        endColor,
+                });
+        invalidate();
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        final int width = r - l;
+        final int height = b - t;
+        final int offsetPixels = mOffsetPixels;
+
+        mMenuContainer.layout(0, 0, width, mMenuSize);
+        offsetMenu(offsetPixels);
+
+        if (USE_TRANSLATIONS) {
+            mContentContainer.layout(0, 0, width, height);
+        } else {
+            mContentContainer.layout(0, offsetPixels, width, height + offsetPixels);
+        }
+    }
+
+    /**
+     * Offsets the menu relative to its original position based on the position of the content.
+     *
+     * @param offsetPixels The number of pixels the content if offset.
+     */
+    private void offsetMenu(int offsetPixels) {
+        if (mOffsetMenu && mMenuSize != 0) {
+            final int menuSize = mMenuSize;
+            final float openRatio = (menuSize - (float) offsetPixels) / menuSize;
+
+            if (USE_TRANSLATIONS) {
+                final int offset = (int) (0.25f * (-openRatio * menuSize));
+                mMenuContainer.setTranslationY(offset);
+
+            } else {
+                final int oldMenuTop = mMenuContainer.getTop();
+                final int offset = (int) (0.25f * (-openRatio * menuSize)) - oldMenuTop;
+                mMenuContainer.offsetTopAndBottom(offset);
+            }
+        }
+    }
+
+    @Override
+    protected void drawDropShadow(Canvas canvas, int offsetPixels) {
+        final int width = getWidth();
+
+        mDropShadowDrawable.setBounds(0, offsetPixels - mDropShadowSize, width, offsetPixels);
+        mDropShadowDrawable.draw(canvas);
+    }
+
+    @Override
+    protected void drawMenuOverlay(Canvas canvas, int offsetPixels) {
+        final int width = getWidth();
+        final float openRatio = ((float) offsetPixels) / mMenuSize;
+
+        mMenuOverlay.setBounds(0, 0, width, offsetPixels);
+        mMenuOverlay.setAlpha((int) (MAX_MENU_OVERLAY_ALPHA * (1.f - openRatio)));
+        mMenuOverlay.draw(canvas);
+    }
+
+    @Override
+    protected void drawArrow(Canvas canvas, int offsetPixels) {
+        // Not implemented yet..
+    }
+
+    @Override
+    protected void onOffsetPixelsChanged(int offsetPixels) {
+        if (USE_TRANSLATIONS) {
+            mContentContainer.setTranslationY(offsetPixels);
+            offsetMenu(offsetPixels);
+            invalidate();
+        } else {
+            mContentContainer.offsetTopAndBottom(offsetPixels - mContentContainer.getTop());
+            offsetMenu(offsetPixels);
+            invalidate();
+        }
+    }
+
+    @Override
+    protected boolean isContentTouch(MotionEvent ev) {
+        return ev.getY() > mOffsetPixels;
+    }
+
+    @Override
+    protected boolean onDownAllowDrag(MotionEvent ev) {
+        return (!mMenuVisible && mInitialMotionY <= mTouchSize)
+                || (mMenuVisible && mInitialMotionY >= mOffsetPixels);
+    }
+
+    @Override
+    protected boolean onMoveAllowDrag(MotionEvent ev, float diff) {
+        return (!mMenuVisible && mInitialMotionY <= mTouchSize && (diff > 0))
+                || (mMenuVisible && mInitialMotionY >= mOffsetPixels);
+    }
+
+    @Override
+    protected void onMoveEvent(float dx) {
+        setOffsetPixels(Math.min(Math.max(mOffsetPixels + (int) dx, 0), mMenuSize));
+    }
+
+    @Override
+    protected void onUpEvent(MotionEvent ev) {
+        final int offsetPixels = mOffsetPixels;
+
+        if (mIsDragging) {
+            mVelocityTracker.computeCurrentVelocity(1000, mMaxVelocity);
+            final int initialVelocity = (int) mVelocityTracker.getXVelocity();
+            mLastMotionY = ev.getY();
+            animateOffsetTo(mVelocityTracker.getYVelocity() > 0 ? mMenuSize : 0, initialVelocity,
+                    true);
+
+            // Close the menu when content is clicked while the menu is visible.
+        } else if (mMenuVisible && ev.getY() > offsetPixels) {
+            closeMenu();
+        }
+    }
+}

--- a/samples/AndroidManifest.xml
+++ b/samples/AndroidManifest.xml
@@ -13,14 +13,14 @@
 
         <activity
             android:name="SamplesActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:launchMode="singleTop" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity android:name="net.simonvt.menudrawer.samples.WindowSample" />
         <activity android:name="net.simonvt.menudrawer.samples.ContentSample" />
         <activity android:name="net.simonvt.menudrawer.samples.ListActivitySample" />
@@ -29,5 +29,13 @@
         <activity
             android:name="net.simonvt.menudrawer.samples.RightMenuSample"
             android:theme="@style/SampleTheme.RightDrawer" />
+        <activity
+            android:name="net.simonvt.menudrawer.samples.TopMenuSample"
+            android:theme="@style/SampleTheme.TopDrawer" >
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="net.simonvt.menudrawer.samples.SamplesActivity" />
+        </activity>
     </application>
+
 </manifest>

--- a/samples/res/layout/activity_topmenu.xml
+++ b/samples/res/layout/activity_topmenu.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="16dp" >
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/sample_topmenu" />
+
+    <TextView
+        android:id="@+id/contentText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/samples/res/layout/menu_top.xml
+++ b/samples/res/layout/menu_top.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="10dp" >
+
+    <TextView
+        android:id="@+id/item1"
+        style="@style/MenuDrawer.Widget.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:drawableLeft="@drawable/ic_action_refresh_dark"
+        android:onClick="onDrawerItemClick"
+        android:tag="Item no. 1"
+        android:text="Item 1" />
+
+    <TextView
+        android:id="@+id/item2"
+        style="@style/MenuDrawer.Widget.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:drawableLeft="@drawable/ic_action_select_all_dark"
+        android:onClick="onDrawerItemClick"
+        android:tag="Item no. 2"
+        android:text="Item 2" />
+
+</LinearLayout>

--- a/samples/res/values/strings.xml
+++ b/samples/res/values/strings.xml
@@ -21,4 +21,9 @@
     <string name="sample_rightmenu">This sample shows how to position the menu to the right of the content.\nRun on
         an API14+ device to see how it interacts with the overflow button.
     </string>
+
+    <string name="sample_topmenu">This sample shows how to position the menu above the content.\n\nYou can control whether
+        the menu appears above or below the title/action bar using MenuDrawer.setDragMode().\n\nIn this case the menu simply
+        contains two items with click listeners attached to them.
+    </string>
 </resources>

--- a/samples/res/values/styles.xml
+++ b/samples/res/values/styles.xml
@@ -33,12 +33,12 @@
 
     <style name="MenuDrawerStyle" parent="Widget.MenuDrawer">
         <item name="mdArrowDrawable">@drawable/menu_arrow</item>
-        <item name="mdMenuWidth">250dp</item>
+        <item name="mdMenuSize">250dp</item>
     </style>
 
     <style name="MenuDrawerStyle.Right" parent="Widget.MenuDrawer">
         <item name="mdArrowDrawable">@drawable/menu_arrow_right</item>
-        <item name="mdMenuWidth">150dp</item>
+        <item name="mdMenuSize">150dp</item>
     </style>
 
 </resources>

--- a/samples/res/values/styles.xml
+++ b/samples/res/values/styles.xml
@@ -41,4 +41,8 @@
         <item name="mdMenuSize">150dp</item>
     </style>
 
+    <style name="MenuDrawerStyle.Top" parent="Widget.MenuDrawer">
+        <item name="mdMenuWidth">64dp</item>
+    </style>
+
 </resources>

--- a/samples/res/values/themes.xml
+++ b/samples/res/values/themes.xml
@@ -11,4 +11,9 @@
 
         <item name="menuDrawerStyle">@style/MenuDrawerStyle.Right</item>
     </style>
+
+    <style name="SampleTheme.TopDrawer" parent="SampleBase">
+        <item name="menuDrawerStyle">@style/MenuDrawerStyle.Top</item>
+    </style>
+
 </resources>

--- a/samples/src/net/simonvt/menudrawer/samples/SamplesActivity.java
+++ b/samples/src/net/simonvt/menudrawer/samples/SamplesActivity.java
@@ -28,6 +28,7 @@ public class SamplesActivity extends ListActivity {
         mAdapter.addSample("ActionBar overlay sample", "A window sample, where the ActionBar is an overlay",
                 ActionBarOverlaySample.class);
         mAdapter.addSample("Right menu", "The menu is positioned to the right of the content", RightMenuSample.class);
+        mAdapter.addSample("Top menu", "The menu is positioned above the content", TopMenuSample.class);
         mAdapter.addSample("Touch Mode", "The menu touch behavior change according to different"
                 + " content view state (Ex: View Pager)", ViewPagerSample.class);
 

--- a/samples/src/net/simonvt/menudrawer/samples/TopMenuSample.java
+++ b/samples/src/net/simonvt/menudrawer/samples/TopMenuSample.java
@@ -1,0 +1,87 @@
+package net.simonvt.menudrawer.samples;
+
+import net.simonvt.widget.MenuDrawer;
+
+import android.app.Activity;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.app.NavUtils;
+import android.support.v4.view.MenuItemCompat;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.TextView;
+
+/**
+ * Sample class illustrating how to add a menu drawer above the content area.
+ */
+public class TopMenuSample extends Activity implements OnClickListener {
+    private static final String STATE_MENUDRAWER =
+            "net.simonvt.menudrawer.samples.ContentSample.menuDrawer";
+
+    private static final int MENU_OVERFLOW = 1;
+
+    private MenuDrawer mMenuDrawer;
+    private TextView mContentTextView;
+
+    @Override
+    protected void onCreate(Bundle inState) {
+        super.onCreate(inState);
+
+        mMenuDrawer = MenuDrawer.attach(this, MenuDrawer.MENU_DRAG_CONTENT, MenuDrawer.MENU_POSITION_TOP);
+        mMenuDrawer.setTouchMode(MenuDrawer.TOUCH_MODE_FULLSCREEN);
+        mMenuDrawer.setContentView(R.layout.activity_topmenu);
+        mMenuDrawer.setMenuView(R.layout.menu_top);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+            getActionBar().setDisplayHomeAsUpEnabled(true);
+
+        mContentTextView = (TextView) findViewById(R.id.contentText);
+        findViewById(R.id.item1).setOnClickListener(this);
+        findViewById(R.id.item2).setOnClickListener(this);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle inState) {
+        super.onRestoreInstanceState(inState);
+        mMenuDrawer.restoreState(inState.getParcelable(STATE_MENUDRAWER));
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(STATE_MENUDRAWER, mMenuDrawer.saveState());
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuItem overflowItem = menu.add(0, MENU_OVERFLOW, 0, null);
+        MenuItemCompat.setShowAsAction(overflowItem, MenuItem.SHOW_AS_ACTION_ALWAYS);
+
+        overflowItem.setIcon(R.drawable.ic_menu_moreoverflow_normal_holo_light);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                NavUtils.navigateUpFromSameTask(this);
+                return true;
+            case MENU_OVERFLOW:
+                mMenuDrawer.toggleMenu();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * Click handler for top drawer items.
+     */
+    @Override
+    public void onClick(View v) {
+        String tag = (String) v.getTag();
+        mContentTextView.setText(String.format("%s clicked.", tag));
+    }
+}


### PR DESCRIPTION
Hey Simon/Jake

First of all, thanks for sharing your app menu drawer implementation.

I've extended the library a little, adding support for placing the drawer above the content, useful for playback controls or other status information.

You can see a use case from one of our apps here where the ongoing cooking timers in a recipe app are displayed in a drawer above the recipe: https://dl.dropbox.com/u/1288556/GoCookTimers.png.

Notes on the implementation:
- All fields now representing width or height (depending on the drawer's gravity) have
  been renamed from 'width' to 'size', e.g. `mMenuWidth` => `mMenuSize`.
- Deprecated `MenuDrawer.setMenuWidth` and `MenuDrawer.setDropShadowWidth` in favor of
  `MenuDrawer.setMenuSize` and `MenuDrawer.setDropShadowSize`. Same story for the 
  styleable attributes `mdMenuWidth` and `mdDropShadowWidth`.
- Added `MenuDrawer.MENU_POSITION_TOP` constant for use with the `gravity` argument in
  `MenuDrawer.attach`. Also refactored the creation of the drawer object into it's own helper method,
  `MenuDrawer.createMenuDrawer`.
- Introduced `HorizontalMenuDrawer` specializing `onMeasure` and touch-related methods for
  horizontally oriented drawers (could use a better name).
- `TopDrawer` is simply a clone of `LeftDrawer`, swapping the x and y axes as appropriate.
- Access modifiers on a few fields and methods in `MenuDrawer` had to be changed from
  `private` to `protected` in order to specialize behavior in the new sub-classes.
- Added a sample activity demonstrating the use of TopDrawer.

Let me know what you think. Thanks!
Michael Nexo
