### PR TITLE
Don't abort touch handling while still dragging.

### DIFF
--- a/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
+++ b/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
@@ -134,7 +134,7 @@ public abstract class HorizontalDrawer extends DraggableDrawer {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        if (!mMenuVisible && (mTouchMode == TOUCH_MODE_NONE)) {
+        if (!mMenuVisible && !mIsDragging && (mTouchMode == TOUCH_MODE_NONE)) {
             return false;
         }
         final int action = ev.getAction() & MotionEvent.ACTION_MASK;

--- a/library/src/net/simonvt/menudrawer/VerticalDrawer.java
+++ b/library/src/net/simonvt/menudrawer/VerticalDrawer.java
@@ -139,7 +139,7 @@ public abstract class VerticalDrawer extends DraggableDrawer {
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        if (!mMenuVisible && (mTouchMode == TOUCH_MODE_NONE)) {
+        if (!mMenuVisible && !mIsDragging && (mTouchMode == TOUCH_MODE_NONE)) {
             return false;
         }
         final int action = ev.getAction() & MotionEvent.ACTION_MASK;


### PR DESCRIPTION
If touch events are ignored during an ongoing drag, and the drawer is dragged closed to the edge where it opens from, the state is not set to STATE_CLOSED.  It is not possible to subsequently open the drawer while in this state, so this change prevents this state.
