### PR TITLE
Add a method for tracking updates on the current open ratio of the menu.

### DIFF
--- a/library/src/net/simonvt/menudrawer/BottomDrawer.java
+++ b/library/src/net/simonvt/menudrawer/BottomDrawer.java
@@ -177,6 +177,10 @@ public class BottomDrawer extends VerticalDrawer {
             offsetMenu(offsetPixels);
             invalidate();
         }
+
+        // Notify any attached listeners of the current open ratio
+        final float openRatio = ((float) Math.abs(offsetPixels)) / mMenuSize;
+        dispatchOnDrawerSlide(openRatio, offsetPixels);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/library/src/net/simonvt/menudrawer/LeftDrawer.java
+++ b/library/src/net/simonvt/menudrawer/LeftDrawer.java
@@ -166,6 +166,10 @@ public class LeftDrawer extends HorizontalDrawer {
             offsetMenu(offsetPixels);
             invalidate();
         }
+
+        // Notify any attached listeners of the current open ratio
+        final float openRatio = ((float) offsetPixels) / mMenuSize;
+        dispatchOnDrawerSlide(openRatio, offsetPixels);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/library/src/net/simonvt/menudrawer/MenuDrawer.java
+++ b/library/src/net/simonvt/menudrawer/MenuDrawer.java
@@ -36,6 +36,13 @@ public abstract class MenuDrawer extends ViewGroup {
          * @param newState The new drawer state.
          */
         void onDrawerStateChange(int oldState, int newState);
+
+        /**
+         * Called when the drawer slides.
+         * @param openRatio ratio for how open the menu is.
+         * @param offsetPixels current left position of the menu.
+         */
+        void onDrawerSlide(float openRatio, float offsetPixels);
     }
 
     /**
@@ -1167,6 +1174,12 @@ public abstract class MenuDrawer extends ViewGroup {
             mMenuContainer.setPadding(0, insets.top, 0, 0);
         }
         return super.fitSystemWindows(insets);
+    }
+
+    protected void dispatchOnDrawerSlide(float openRatio, float offsetPixels) {
+        if (mOnDrawerStateChangeListener != null) {
+            mOnDrawerStateChangeListener.onDrawerSlide(openRatio, offsetPixels);
+        }
     }
 
     /**

--- a/library/src/net/simonvt/menudrawer/RightDrawer.java
+++ b/library/src/net/simonvt/menudrawer/RightDrawer.java
@@ -180,6 +180,10 @@ public class RightDrawer extends HorizontalDrawer {
             offsetMenu(offsetPixels);
             invalidate();
         }
+
+        // Notify any attached listeners of the current open ratio
+        final float openRatio = ((float) Math.abs(offsetPixels)) / mMenuSize;
+        dispatchOnDrawerSlide(openRatio, offsetPixels);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/library/src/net/simonvt/menudrawer/TopDrawer.java
+++ b/library/src/net/simonvt/menudrawer/TopDrawer.java
@@ -169,6 +169,10 @@ public class TopDrawer extends VerticalDrawer {
             offsetMenu(offsetPixels);
             invalidate();
         }
+
+        // Notify any attached listeners of the current open ratio
+        final float openRatio = ((float) offsetPixels) / mMenuSize;
+        dispatchOnDrawerSlide(openRatio, offsetPixels);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/samples/src/net/simonvt/menudrawer/samples/FragmentSample.java
+++ b/samples/src/net/simonvt/menudrawer/samples/FragmentSample.java
@@ -43,6 +43,11 @@ public class FragmentSample extends BaseListSample {
                     commitTransactions();
                 }
             }
+
+            @Override
+            public void onDrawerSlide(float openRatio, float offsetPixels) {
+                // Do nothing
+            }
         });
     }
 

--- a/samples/src/net/simonvt/menudrawer/samples/ListActivitySample.java
+++ b/samples/src/net/simonvt/menudrawer/samples/ListActivitySample.java
@@ -73,6 +73,11 @@ public class ListActivitySample extends ListActivity {
                         mMenuDrawer.setOnDrawerStateChangeListener(null);
                     }
                 }
+
+                @Override
+                public void onDrawerSlide(float openRatio, float offsetPixels) {
+                    // Do nothing
+                }
             });
         }
     }


### PR DESCRIPTION
This will help us support the new ActionBar icon animation for the new "official" Sliding Drawer Navigation UI pattern. While at the moment, this is only useful for the standard LeftDrawer, I thought I would make the listener more abstract and have it work from all types of draggable drawers.

Let me know if you have any questions/concerns.
