### PR TITLE
Added option to disable menu overlay

### DIFF
--- a/library/src/net/simonvt/menudrawer/DraggableDrawer.java
+++ b/library/src/net/simonvt/menudrawer/DraggableDrawer.java
@@ -145,6 +145,11 @@ public abstract class DraggableDrawer extends MenuDrawer {
     protected boolean mOffsetMenu = true;
 
     /**
+     * Indicated whether an overlay should be drawn over the menu when dragging the drawer.
+     */
+    protected boolean mDrawMenuOverlay = true;
+
+    /**
      * Distance in px from closed position from where the drawer is considered closed with regards to touch events.
      */
     protected int mCloseEnough;
@@ -226,6 +231,16 @@ public abstract class DraggableDrawer extends MenuDrawer {
 
     public boolean getOffsetMenuEnabled() {
         return mOffsetMenu;
+    }
+
+    @Override
+    public void setDrawMenuOverlay(boolean drawMenuOverlay) {
+        mDrawMenuOverlay = drawMenuOverlay;
+    }
+
+    @Override
+    public boolean getDrawMenuOverlay() {
+        return mDrawMenuOverlay;
     }
 
     public void peekDrawer() {
@@ -641,7 +656,7 @@ public abstract class DraggableDrawer extends MenuDrawer {
         super.dispatchDraw(canvas);
         final int offsetPixels = (int) mOffsetPixels;
 
-        if (offsetPixels != 0) drawMenuOverlay(canvas, offsetPixels);
+        if (mDrawMenuOverlay && offsetPixels != 0) drawMenuOverlay(canvas, offsetPixels);
         if (mDropShadowEnabled) drawDropShadow(canvas, offsetPixels);
         if (mActiveIndicator != null) drawIndicator(canvas, offsetPixels);
     }

--- a/library/src/net/simonvt/menudrawer/MenuDrawer.java
+++ b/library/src/net/simonvt/menudrawer/MenuDrawer.java
@@ -808,6 +808,21 @@ public abstract class MenuDrawer extends ViewGroup {
      */
     public abstract boolean getOffsetMenuEnabled();
 
+    /**
+     * Enables or disables drawing the dark overlay over menu when dragging the drawer.
+     *
+     * @param drawMenuOverlay True to draw the overlay, false otherwise.
+     */
+    public abstract void setDrawMenuOverlay(boolean drawMenuOverlay);
+
+
+    /**
+     * Indicates whether the menu overlay is being drawn when dragging the drawer.
+     *
+     * @return True if the overlay is being drawn, false otherwise.
+     */
+    public abstract boolean getDrawMenuOverlay();
+
     public int getDrawerState() {
         return mDrawerState;
     }

--- a/library/src/net/simonvt/menudrawer/StaticDrawer.java
+++ b/library/src/net/simonvt/menudrawer/StaticDrawer.java
@@ -173,6 +173,15 @@ public abstract class StaticDrawer extends MenuDrawer {
     }
 
     @Override
+    public void setDrawMenuOverlay(boolean drawMenuOverlay) {
+    }
+
+    @Override
+    public boolean getDrawMenuOverlay() {
+        return false;
+    }
+
+    @Override
     public void peekDrawer() {
     }
 


### PR DESCRIPTION
In some cases the dark overlay when sliding the drawer might not be desired. This pull request adds "setDrawMenuOverlay" and "getDrawMenuOverlay" options to MenuDrawer class so the user can disable the dark overlay over menu.
