### PR TITLE
HorizontalDrawer.onInterceptTouchEvent() exception

### DIFF
--- a/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
+++ b/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
@@ -104,6 +104,9 @@ public abstract class HorizontalDrawer extends DraggableDrawer {
 
                 final int pointerIndex = ev.findPointerIndex(activePointerId);
 
+                if(pointerIndex==-1) {
+                	break;
+                }
                 final float x = ev.getX(pointerIndex);
                 final float dx = x - mLastMotionX;
                 final float xDiff = Math.abs(dx);

--- a/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
+++ b/library/src/net/simonvt/menudrawer/HorizontalDrawer.java
@@ -105,8 +105,9 @@ public abstract class HorizontalDrawer extends DraggableDrawer {
                 final int pointerIndex = ev.findPointerIndex(activePointerId);
 
                 if(pointerIndex==-1) {
-                	break;
+                	break; //pointer identifier data is not available
                 }
+                
                 final float x = ev.getX(pointerIndex);
                 final float dx = x - mLastMotionX;
                 final float xDiff = Math.abs(dx);
@@ -184,7 +185,11 @@ public abstract class HorizontalDrawer extends DraggableDrawer {
             case MotionEvent.ACTION_MOVE: {
                 if (!mIsDragging) {
                     final int pointerIndex = ev.findPointerIndex(mActivePointerId);
-
+                    
+                    if(pointerIndex==-1) {
+                    	break; //pointer identifier data is not available
+                    }
+                    
                     final float x = ev.getX(pointerIndex);
                     final float dx = x - mLastMotionX;
                     final float xDiff = Math.abs(dx);
@@ -208,7 +213,7 @@ public abstract class HorizontalDrawer extends DraggableDrawer {
                     startLayerTranslation();
 
                     final int pointerIndex = ev.findPointerIndex(mActivePointerId);
-
+                    
                     final float x = ev.getX(pointerIndex);
                     final float dx = x - mLastMotionX;
 

--- a/library/src/net/simonvt/menudrawer/VerticalDrawer.java
+++ b/library/src/net/simonvt/menudrawer/VerticalDrawer.java
@@ -105,7 +105,11 @@ public abstract class VerticalDrawer extends DraggableDrawer {
                 }
 
                 final int pointerIndex = ev.findPointerIndex(activePointerId);
-
+                
+                if(pointerIndex==-1) {
+                	break; //pointer identifier data is not available
+                }
+                
                 final float x = ev.getX(pointerIndex);
                 final float dx = x - mLastMotionX;
                 final float xDiff = Math.abs(dx);
@@ -188,6 +192,10 @@ public abstract class VerticalDrawer extends DraggableDrawer {
             case MotionEvent.ACTION_MOVE: {
                 if (!mIsDragging) {
                     final int pointerIndex = ev.findPointerIndex(mActivePointerId);
+                    
+                    if(pointerIndex==-1) {
+                    	break; //pointer identifier data is not available
+                    }
 
                     final float x = ev.getX(pointerIndex);
                     final float dx = x - mLastMotionX;


### PR DESCRIPTION
I am using your library with ImageViewZoom library.  when an image is pinched it was often causing an out of range exception in onInterceptTouchEvent() due to the ev.findPointerIndex() call returning -1 and passing it to ev.getX().  

Regards,
Kevin
